### PR TITLE
Fix namespace handling when including document from default namespace 

### DIFF
--- a/src/main/java/org/apache/maven/xinclude/stax/XIncludeStreamReader.java
+++ b/src/main/java/org/apache/maven/xinclude/stax/XIncludeStreamReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.xinclude.stax;
 
-import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -66,6 +65,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
+import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
+import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI;
+import static javax.xml.XMLConstants.XML_NS_PREFIX;
 import static javax.xml.XMLConstants.XML_NS_URI;
 
 /**
@@ -74,6 +78,7 @@ import static javax.xml.XMLConstants.XML_NS_URI;
 @SuppressWarnings("checkstyle:MissingSwitchDefault")
 class XIncludeStreamReader extends StreamReaderDelegate {
 
+    private static final String XMLNS_NS_PREFIX = "xmlns";
     private static final String XINCLUDE_NAMESPACE = "http://www.w3.org/2001/XInclude";
     private static final String XINCLUDE_INCLUDE = "include";
     private static final String XINCLUDE_FALLBACK = "fallback";
@@ -270,9 +275,9 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                         p = np instanceof Element ? (Element) np : null;
                     }
                     if (!Objects.equals(curLang, impLang)) {
-                        resNode.setAttributeNS(XML_NS_URI, "xml:lang", impLang);
+                        resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":lang", impLang);
                     }
-                    resNode.setAttributeNS(XML_NS_URI, "xml:base", input.getSystemId());
+                    resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":base", input.getSystemId());
 
                     NamespaceContext context =
                             this.contextStack.peek().getReader().getNamespaceContext();
@@ -284,8 +289,8 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                                 && context.getNamespaceURI(prefix) != null
                                 && !uri.equals(context.getNamespaceURI(prefix))) {
                             resNode.setAttributeNS(
-                                    XMLConstants.XMLNS_ATTRIBUTE_NS_URI,
-                                    prefix.isEmpty() ? "xmlns" : "xmlns:" + prefix,
+                                    XMLNS_ATTRIBUTE_NS_URI,
+                                    prefix.isEmpty() ? XMLNS_ATTRIBUTE : XMLNS_NS_PREFIX + ":" + prefix,
                                     uri);
                         }
                     }
@@ -303,7 +308,7 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                         }
                     }
                     if (setXmlId != null) {
-                        resNode.setAttributeNS(XML_NS_URI, "xml:id", setXmlId);
+                        resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":id", setXmlId);
                     }
 
                     XMLStreamReader sr = factory.createXMLStreamReader(new DOMSource(resNode));
@@ -477,24 +482,24 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                 Attr attr = (Attr) attributes.item(i);
                 String name = attr.getNodeName();
                 // Handle xmlns:prefix declarations
-                if (name.startsWith("xmlns:")) {
-                    String prefix = name.substring(6); // length of "xmlns:"
+                if (XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
+                    String prefix = attr.getLocalName();
                     if (!namespaces.containsKey(prefix)) {
                         namespaces.put(prefix, attr.getValue());
                     }
                 }
                 // Handle default namespace declaration
-                else if ("xmlns".equals(name)) {
-                    if (!namespaces.containsKey("")) {
-                        namespaces.put("", attr.getValue());
+                else if (XMLNS_ATTRIBUTE.equals(name)) {
+                    if (!namespaces.containsKey(DEFAULT_NS_PREFIX)) {
+                        namespaces.put(DEFAULT_NS_PREFIX, attr.getValue());
                     }
                 }
             }
             current = current.getParentNode();
         }
         // Add empty namespace
-        if (!namespaces.containsKey("")) {
-            namespaces.put("", "");
+        if (!namespaces.containsKey(DEFAULT_NS_PREFIX)) {
+            namespaces.put(DEFAULT_NS_PREFIX, NULL_NS_URI);
         }
         return namespaces;
     }

--- a/src/main/java/org/apache/maven/xinclude/stax/XIncludeStreamReader.java
+++ b/src/main/java/org/apache/maven/xinclude/stax/XIncludeStreamReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.xinclude.stax;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -65,11 +66,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
-import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
-import static javax.xml.XMLConstants.NULL_NS_URI;
-import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
-import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI;
-import static javax.xml.XMLConstants.XML_NS_PREFIX;
 import static javax.xml.XMLConstants.XML_NS_URI;
 
 /**
@@ -78,7 +74,6 @@ import static javax.xml.XMLConstants.XML_NS_URI;
 @SuppressWarnings("checkstyle:MissingSwitchDefault")
 class XIncludeStreamReader extends StreamReaderDelegate {
 
-    private static final String XMLNS_NS_PREFIX = "xmlns";
     private static final String XINCLUDE_NAMESPACE = "http://www.w3.org/2001/XInclude";
     private static final String XINCLUDE_INCLUDE = "include";
     private static final String XINCLUDE_FALLBACK = "fallback";
@@ -275,9 +270,9 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                         p = np instanceof Element ? (Element) np : null;
                     }
                     if (!Objects.equals(curLang, impLang)) {
-                        resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":lang", impLang);
+                        resNode.setAttributeNS(XML_NS_URI, "xml:lang", impLang);
                     }
-                    resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":base", input.getSystemId());
+                    resNode.setAttributeNS(XML_NS_URI, "xml:base", input.getSystemId());
 
                     NamespaceContext context =
                             this.contextStack.peek().getReader().getNamespaceContext();
@@ -289,8 +284,8 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                                 && context.getNamespaceURI(prefix) != null
                                 && !uri.equals(context.getNamespaceURI(prefix))) {
                             resNode.setAttributeNS(
-                                    XMLNS_ATTRIBUTE_NS_URI,
-                                    prefix.isEmpty() ? XMLNS_ATTRIBUTE : XMLNS_NS_PREFIX + ":" + prefix,
+                                    XMLConstants.XMLNS_ATTRIBUTE_NS_URI,
+                                    prefix.isEmpty() ? "xmlns" : "xmlns:" + prefix,
                                     uri);
                         }
                     }
@@ -308,7 +303,7 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                         }
                     }
                     if (setXmlId != null) {
-                        resNode.setAttributeNS(XML_NS_URI, XML_NS_PREFIX + ":id", setXmlId);
+                        resNode.setAttributeNS(XML_NS_URI, "xml:id", setXmlId);
                     }
 
                     XMLStreamReader sr = factory.createXMLStreamReader(new DOMSource(resNode));
@@ -482,24 +477,24 @@ class XIncludeStreamReader extends StreamReaderDelegate {
                 Attr attr = (Attr) attributes.item(i);
                 String name = attr.getNodeName();
                 // Handle xmlns:prefix declarations
-                if (XMLNS_ATTRIBUTE_NS_URI.equals(attr.getNamespaceURI())) {
-                    String prefix = attr.getLocalName();
+                if (name.startsWith("xmlns:")) {
+                    String prefix = name.substring(6); // length of "xmlns:"
                     if (!namespaces.containsKey(prefix)) {
                         namespaces.put(prefix, attr.getValue());
                     }
                 }
                 // Handle default namespace declaration
-                else if (XMLNS_ATTRIBUTE.equals(name)) {
-                    if (!namespaces.containsKey(DEFAULT_NS_PREFIX)) {
-                        namespaces.put(DEFAULT_NS_PREFIX, attr.getValue());
+                else if ("xmlns".equals(name)) {
+                    if (!namespaces.containsKey("")) {
+                        namespaces.put("", attr.getValue());
                     }
                 }
             }
             current = current.getParentNode();
         }
         // Add empty namespace
-        if (!namespaces.containsKey(DEFAULT_NS_PREFIX)) {
-            namespaces.put(DEFAULT_NS_PREFIX, NULL_NS_URI);
+        if (!namespaces.containsKey("")) {
+            namespaces.put("", "");
         }
         return namespaces;
     }

--- a/src/test/java/org/apache/maven/xinclude/stax/XIncludeTest.java
+++ b/src/test/java/org/apache/maven/xinclude/stax/XIncludeTest.java
@@ -72,8 +72,9 @@ class XIncludeTest {
     }
 
     @Test
-    void testInclusionWithNamespaces() throws Exception {
-        String input = "<?xml version='1.0'?>\n" + "<document xmlns='http://example.org' xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+    void testInclusionWithEmptyNamespaces() throws Exception {
+        String input = "<?xml version='1.0'?>\n"
+                + "<document xmlns='http://example.org' xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
                 + "  <p>120 Mz is adequate for an average home user.</p>\n"
                 + "  <xi:include href=\"disclaimer.xml\"/>\n"
                 + "</document>";
@@ -84,7 +85,8 @@ class XIncludeTest {
                         + "  and should not be interpreted as official policy endorsed by this\n"
                         + "  organization.</p>\n"
                         + "</disclaimer>");
-        String expected = "<?xml version='1.0'?>\n" + "<document xmlns=\"http://example.org\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+        String expected = "<?xml version='1.0'?>\n"
+                + "<document xmlns=\"http://example.org\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
                 + "  <p>120 Mz is adequate for an average home user.</p>\n"
                 + "  <disclaimer xmlns=\"\" xml:base=\"http://www.example.com/disclaimer.xml\">\n"
                 + "  <p>The opinions represented herein represent those of the individual\n"
@@ -92,6 +94,36 @@ class XIncludeTest {
                 + "  organization.</p>\n"
                 + "</disclaimer>\n"
                 + "</document>";
+
+        assertXInclude(input, includes, expected);
+    }
+
+    @Test
+    void testInclusionWithDifferentNamespaces() throws Exception {
+        String input = "<?xml version='1.0'?>\n"
+                + "<doc:document xmlns:doc=\"http://example.org/doc\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+                + "  <doc:p>120 Mz is adequate for an average home user.</doc:p>\n"
+                + "  <xi:include href=\"disclaimer.xml\" xpointer=\"element(/1/1)\"/>\n"
+                + "</doc:document>";
+        Map<String, String> includes = Collections.singletonMap(
+                "http://www.example.com/disclaimer.xml",
+                "<?xml version='1.0'?>\n"
+                        + "<wrapper xmlns:doc=\"http://example.org/disclaimer\">\n"
+                        + "  <doc:disclaimer>\n"
+                        + "    <doc:p>The opinions represented herein represent those of the individual\n"
+                        + "    and should not be interpreted as official policy endorsed by this\n"
+                        + "    organization.</doc:p>\n"
+                        + "  </doc:disclaimer>\n"
+                        + "</wrapper>");
+        String expected = "<?xml version='1.0'?>\n"
+                + "<doc:document xmlns:doc=\"http://example.org/doc\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+                + "  <doc:p>120 Mz is adequate for an average home user.</doc:p>\n"
+                + "  <doc:disclaimer xmlns:doc=\"http://example.org/disclaimer\" xml:base=\"http://www.example.com/disclaimer.xml\">\n"
+                + "    <doc:p>The opinions represented herein represent those of the individual\n"
+                + "    and should not be interpreted as official policy endorsed by this\n"
+                + "    organization.</doc:p>\n"
+                + "  </doc:disclaimer>\n"
+                + "</doc:document>";
 
         assertXInclude(input, includes, expected);
     }

--- a/src/test/java/org/apache/maven/xinclude/stax/XIncludeTest.java
+++ b/src/test/java/org/apache/maven/xinclude/stax/XIncludeTest.java
@@ -72,6 +72,31 @@ class XIncludeTest {
     }
 
     @Test
+    void testInclusionWithNamespaces() throws Exception {
+        String input = "<?xml version='1.0'?>\n" + "<document xmlns='http://example.org' xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+                + "  <p>120 Mz is adequate for an average home user.</p>\n"
+                + "  <xi:include href=\"disclaimer.xml\"/>\n"
+                + "</document>";
+        Map<String, String> includes = Collections.singletonMap(
+                "http://www.example.com/disclaimer.xml",
+                "<?xml version='1.0'?>\n" + "<disclaimer>\n"
+                        + "  <p>The opinions represented herein represent those of the individual\n"
+                        + "  and should not be interpreted as official policy endorsed by this\n"
+                        + "  organization.</p>\n"
+                        + "</disclaimer>");
+        String expected = "<?xml version='1.0'?>\n" + "<document xmlns=\"http://example.org\" xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
+                + "  <p>120 Mz is adequate for an average home user.</p>\n"
+                + "  <disclaimer xmlns=\"\" xml:base=\"http://www.example.com/disclaimer.xml\">\n"
+                + "  <p>The opinions represented herein represent those of the individual\n"
+                + "  and should not be interpreted as official policy endorsed by this\n"
+                + "  organization.</p>\n"
+                + "</disclaimer>\n"
+                + "</document>";
+
+        assertXInclude(input, includes, expected);
+    }
+
+    @Test
     void testTextualInclusion() throws Exception {
         String input = "<?xml version='1.0'?>\n" + "<document xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
                 + "  <p>This document has been accessed\n"


### PR DESCRIPTION
#20

This new test should pass but fails. The included document should not necessarily assume that its default namespace is the same as the document it's being merged into.